### PR TITLE
Fix UB leading to segfault in memory estimator

### DIFF
--- a/src/GameTree.cpp
+++ b/src/GameTree.cpp
@@ -527,6 +527,7 @@ long long GameTree::re_estimate_tree_memory(const shared_ptr<GameTreeNode>& node
         shared_ptr<GameTreeNode> children = chance_node->getChildren();
         return re_estimate_tree_memory(children,deck_num, p1range_num, p2range_num, num_current_deal * (deck_num));
     }
+    return 0;
 }
 
 void GameTree::recurrentPrintTree(const shared_ptr<GameTreeNode>& node, int depth, int depth_limit) {


### PR DESCRIPTION
The memory estimation feature was segfaulting when the program was compiled with GCC and optimizations because the re_estimate_tree_memory function didn't have a return value in some cases, which is undefined behavior. (GCC optimizes out the check for the chance node and just assumes any non-action node is a chance node). This fixes that.