### PR TITLE
Fix switch-case warning: control reaches end of non-void function

### DIFF
--- a/src/nodes/GameActions.cpp
+++ b/src/nodes/GameActions.cpp
@@ -34,6 +34,9 @@ string GameActions::pokerActionToString(GameTreeNode::PokerActions pokerActions)
         case GameTreeNode::PokerActions::CHECK :   return "CHECK";
         case GameTreeNode::PokerActions::FOLD :   return "FOLD";
         case GameTreeNode::PokerActions::CALL :   return "CALL";
+        default:{
+            throw runtime_error("PokerActions not found");
+        }
     }
 }
 


### PR DESCRIPTION
Update GameActions.cpp: Fix switch-case warning: control reaches end of non-void function