### PR TITLE
Strategy with range indication

### DIFF
--- a/include/ui/strategyitemdelegate.h
+++ b/include/ui/strategyitemdelegate.h
@@ -29,7 +29,7 @@ protected:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paint_strategy(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, bool withEVs = false) const;
     void paint_range(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void paint_evs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, bool finish = true) const;
+    void paint_evs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 };
 
 #endif // STRATEGYITEMDELEGATE_H

--- a/include/ui/strategyitemdelegate.h
+++ b/include/ui/strategyitemdelegate.h
@@ -27,9 +27,9 @@ private:
 
 protected:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void paint_strategy(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paint_strategy(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, bool withEVs = false) const;
     void paint_range(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void paint_evs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paint_evs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, bool finish = true) const;
 };
 
 #endif // STRATEGYITEMDELEGATE_H

--- a/include/ui/tablestrategymodel.h
+++ b/include/ui/tablestrategymodel.h
@@ -48,6 +48,7 @@ public:
     map<int,Card> cardint2card;
     TreeItem * treeItem = NULL;// = static_cast<TreeItem*>(index.internalPointer());
     QSolverJob* get_solver(){return this->qSolverJob;};
+    int current_player;
 
 private:
     QSolverJob* qSolverJob;

--- a/include/ui/tablestrategymodel.h
+++ b/include/ui/tablestrategymodel.h
@@ -37,6 +37,7 @@ public:
     const vector<pair<GameActions,float>> get_strategy(int i,int j) const;
     const vector<pair<GameActions,pair<float,float>>> get_total_strategy() const;
     const vector<float> get_ev_grid(int i,int j) const;
+    const vector<float> get_strategies_evs(int i,int j) const;
     vector<vector<vector<float>>> current_strategy; // cardint(52) * cardint(52) * strategy_type
     vector<vector<vector<float>>> current_evs; // cardint(52) * cardint(52) * strategy_type
     vector<vector<float>> p1_range; // cardint(52) * cardint(52)

--- a/src/ui/detailitemdelegate.cpp
+++ b/src/ui/detailitemdelegate.cpp
@@ -57,7 +57,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
-// get range data - copied initially from paint_range - probably could need cleanup
+            // get range data - copied initially from paint_range
             float range_number;
             if(0 == detailViewerModel->tableStrategyModel->current_player){
                 range_number = detailViewerModel->tableStrategyModel->p1_range[card1][card2];
@@ -65,7 +65,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
                 range_number = detailViewerModel->tableStrategyModel->p2_range[card1][card2];
             }
             if(range_number < 0 || range_number > 1) throw runtime_error("range number incorrect in strategyitemdeletage");
-// got range data
+            // got range data
 
             float not_in_range = 1 - range_number;
             int niR_height = (int)(not_in_range * option.rect.height());
@@ -248,7 +248,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
-// get range data - copied initally from paint_range - probably could need cleanup
+            // get range data - copied initally from paint_range - probably could need cleanup
             float range_number;
             if(0 == detailViewerModel->tableStrategyModel->current_player){
                 range_number = detailViewerModel->tableStrategyModel->p1_range[card1][card2];
@@ -257,7 +257,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
             }
 
             if(range_number < 0 || range_number > 1) throw runtime_error("range number incorrect in strategyitemdeletage");
-// got range data
+            // got range data
 
             float not_in_range = 1 - range_number;
             int niR_height = (int)(not_in_range * option.rect.height());
@@ -276,13 +276,11 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
             int bet_raise_num = 0;
             for(int i = 0;i < strategy.size();i ++){
                 GameActions one_action = gameActions[i];
-//                float normalized_ev = normalization_tanh(detailViewerModel->tableStrategyModel->get_solver()->stack * 0.5,evs[i]);
-                float normalized_ev = normalization_tanh(node->getPot() * 4,evs[i]);
+                float normalized_ev = normalization_tanh(node->getPot() * 3,evs[i]);
                 QBrush brush(Qt::gray);
                 if(one_action.getAction() != GameTreeNode::PokerActions::FOLD){
                     if(one_action.getAction() == GameTreeNode::PokerActions::CHECK
                     || one_action.getAction() == GameTreeNode::PokerActions::CALL){
-//                        brush = QBrush(Qt::green);
                         int green = 255;
                         int blue = max((int)(225 - normalized_ev * 175),55);
                         int red = 55;
@@ -290,8 +288,6 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
                 }
                 else if(one_action.getAction() == GameTreeNode::PokerActions::BET
                 || one_action.getAction() == GameTreeNode::PokerActions::RAISE){
-//                     int color_base = max(128 - 32 * bet_raise_num - 1,0);
-//                     brush = QBrush(QColor(255,color_base,color_base));
                      int color_base = max(128 - 32 * bet_raise_num - 1,0);
                      int blue = max((int)(255 - normalized_ev * (255 - color_base)), color_base);
                      int red = color_base + min((int)(normalized_ev * (255-color_base)),255-color_base);;

--- a/src/ui/detailitemdelegate.cpp
+++ b/src/ui/detailitemdelegate.cpp
@@ -28,6 +28,16 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
         }
         int ind = index.row() * detailViewerModel->columns + index.column();
 
+// do range data preperation - copied from paint_range - probably could need cleanup
+        vector<pair<int,int>> card_cords;
+        if(0 == detailViewerModel->tableStrategyModel->current_player ){
+            card_cords = detailViewerModel->tableStrategyModel->ui_p1_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
+        }else{
+            card_cords = detailViewerModel->tableStrategyModel->ui_p2_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
+        }
+
+// did range data preperation
+
         if(ind < strategy_number){
 
             pair<int,int> strategy_ui_table = detailViewerModel->tableStrategyModel->ui_strategy_table[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j][ind];
@@ -57,11 +67,26 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
-            int disable_height = (int)(fold_prob * option.rect.height());
-            int remain_height = option.rect.height() - disable_height;
+// get range data - copied from paint_range - probably could need cleanup
+            pair<int,int> cord = card_cords[ind];
+            float range_number;
+            if(0 == detailViewerModel->tableStrategyModel->current_player){
+                range_number = detailViewerModel->tableStrategyModel->p1_range[cord.first][cord.second];
+            }else{
+                range_number = detailViewerModel->tableStrategyModel->p2_range[cord.first][cord.second];
+            }
+
+            if(range_number < 0 || range_number > 1) throw runtime_error("range number incorrect in strategyitemdeletage");
+// got range data
+
+            float not_in_range = 1 - range_number;
+            int niR_height = (int)(not_in_range * option.rect.height());
+
+            int disable_height = (int)(fold_prob * (option.rect.height()-niR_height));
+            int remain_height = option.rect.height() - niR_height - disable_height;
 
             // draw background for flod
-            QRect rect(option.rect.left(), option.rect.top(),\
+            QRect rect(option.rect.left(), option.rect.top() + niR_height,\
                  option.rect.width(), disable_height);
             QBrush brush(QColor	(0,191,255));
             painter->fillRect(rect, brush);
@@ -89,7 +114,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
                 int delta_x = (int)(option.rect.width() * last_prob);
                 int delta_width = (int)(option.rect.width() * (last_prob + strategy_without_fold[ind])) - (int)(option.rect.width() * last_prob);
 
-                QRect rect(option.rect.left() + delta_x, option.rect.top() + disable_height,\
+                QRect rect(option.rect.left() + delta_x, option.rect.top() + niR_height + disable_height,\
                  delta_width , remain_height);
                 painter->fillRect(rect, brush);
 
@@ -205,6 +230,17 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
         }
         int ind = index.row() * detailViewerModel->columns + index.column();
 
+// do range data preperation - copied from paint_range - probably could need cleanup
+        vector<pair<int,int>> card_cords;
+        if(0 == detailViewerModel->tableStrategyModel->current_player ){
+            card_cords = detailViewerModel->tableStrategyModel->ui_p1_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
+        }else{
+            card_cords = detailViewerModel->tableStrategyModel->ui_p2_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
+        }
+
+// did range data preperation
+
+
         if(ind < strategy_number){
 
             pair<int,int> strategy_ui_table = detailViewerModel->tableStrategyModel->ui_strategy_table[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j][ind];
@@ -235,11 +271,26 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
-            int disable_height = (int)(fold_prob * option.rect.height());
-            int remain_height = option.rect.height() - disable_height;
+// get range data - copied from paint_range - probably could need cleanup
+            pair<int,int> cord = card_cords[ind];
+            float range_number;
+            if(0 == detailViewerModel->tableStrategyModel->current_player){
+                range_number = detailViewerModel->tableStrategyModel->p1_range[cord.first][cord.second];
+            }else{
+                range_number = detailViewerModel->tableStrategyModel->p2_range[cord.first][cord.second];
+            }
+
+            if(range_number < 0 || range_number > 1) throw runtime_error("range number incorrect in strategyitemdeletage");
+// got range data
+
+            float not_in_range = 1 - range_number;
+            int niR_height = (int)(not_in_range * option.rect.height());
+
+            int disable_height = (int)(fold_prob * (option.rect.height()-niR_height));
+            int remain_height = option.rect.height() - niR_height - disable_height;
 
             // draw background for flod
-            QRect rect(option.rect.left(), option.rect.top(),\
+            QRect rect(option.rect.left(), option.rect.top() + niR_height,\
                  option.rect.width(), disable_height);
             QBrush brush(QColor	(0,191,255));
             painter->fillRect(rect, brush);
@@ -267,7 +318,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
                 int delta_x = (int)(option.rect.width() * last_prob);
                 int delta_width = (int)(option.rect.width() * (last_prob + strategy_without_fold[ind])) - (int)(option.rect.width() * last_prob);
 
-                QRect rect(option.rect.left() + delta_x, option.rect.top() + disable_height,\
+                QRect rect(option.rect.left() + delta_x, option.rect.top() + niR_height + disable_height,\
                  delta_width , remain_height);
                 painter->fillRect(rect, brush);
 

--- a/src/ui/detailitemdelegate.cpp
+++ b/src/ui/detailitemdelegate.cpp
@@ -68,17 +68,19 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
             // got range data
 
             float not_in_range = 1 - range_number;
-            int niR_height = (int)(not_in_range * option.rect.height());
+            int niR_height = (int)(not_in_range * option.rect.height() * 0.975);
 
-            int disable_height = (int)(fold_prob * (option.rect.height()-niR_height));
+            int disable_height = (int)(0.5 + fold_prob * (option.rect.height()-niR_height));
             int remain_height = option.rect.height() - niR_height - disable_height;
 
             // draw background for flod
+        if ( disable_height > 0) {
             QRect rect(option.rect.left(), option.rect.top() + niR_height,\
                  option.rect.width(), disable_height);
             QBrush brush(QColor	(0,191,255));
             painter->fillRect(rect, brush);
-
+        }
+        if (remain_height > 0){
             int ind = 0;
             float last_prob = 0;
             int bet_raise_num = 0;
@@ -105,6 +107,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
                 QRect rect(option.rect.left() + delta_x, option.rect.top() + niR_height + disable_height,\
                  delta_width , remain_height);
                 painter->fillRect(rect, brush);
+            }
 
                 last_prob += strategy_without_fold[ind];
                 ind += 1;
@@ -260,17 +263,19 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
             // got range data
 
             float not_in_range = 1 - range_number;
-            int niR_height = (int)(not_in_range * option.rect.height());
+            int niR_height = (int)(not_in_range * option.rect.height() * 0.975);
 
-            int disable_height = (int)(fold_prob * (option.rect.height()-niR_height));
+            int disable_height = (int)(0.5 + fold_prob * (option.rect.height()-niR_height));
             int remain_height = option.rect.height() - niR_height - disable_height;
 
             // draw background for flod
+        if (disable_height > 0) {
             QRect rect(option.rect.left(), option.rect.top() + niR_height,\
                  option.rect.width(), disable_height);
             QBrush brush(QColor	(0,191,255));
             painter->fillRect(rect, brush);
-
+        }
+        if (remain_height > 0){
             int ind = 0;
             float last_prob = 0;
             int bet_raise_num = 0;
@@ -305,6 +310,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
                 QRect rect(option.rect.left() + delta_x, option.rect.top() + niR_height + disable_height,\
                  delta_width , remain_height);
                 painter->fillRect(rect, brush);
+            }
 
                 last_prob += strategy_without_fold[ind];
                 ind += 1;

--- a/src/ui/detailitemdelegate.cpp
+++ b/src/ui/detailitemdelegate.cpp
@@ -276,7 +276,8 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
             int bet_raise_num = 0;
             for(int i = 0;i < strategy.size();i ++){
                 GameActions one_action = gameActions[i];
-                float normalized_ev = normalization_tanh(detailViewerModel->tableStrategyModel->get_solver()->stack,evs[i]);
+//                float normalized_ev = normalization_tanh(detailViewerModel->tableStrategyModel->get_solver()->stack * 0.5,evs[i]);
+                float normalized_ev = normalization_tanh(node->getPot() * 4,evs[i]);
                 QBrush brush(Qt::gray);
                 if(one_action.getAction() != GameTreeNode::PokerActions::FOLD){
                     if(one_action.getAction() == GameTreeNode::PokerActions::CHECK

--- a/src/ui/detailitemdelegate.cpp
+++ b/src/ui/detailitemdelegate.cpp
@@ -28,16 +28,6 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
         }
         int ind = index.row() * detailViewerModel->columns + index.column();
 
-// do range data preperation - copied from paint_range - probably could need cleanup
-        vector<pair<int,int>> card_cords;
-        if(0 == detailViewerModel->tableStrategyModel->current_player ){
-            card_cords = detailViewerModel->tableStrategyModel->ui_p1_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
-        }else{
-            card_cords = detailViewerModel->tableStrategyModel->ui_p2_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
-        }
-
-// did range data preperation
-
         if(ind < strategy_number){
 
             pair<int,int> strategy_ui_table = detailViewerModel->tableStrategyModel->ui_strategy_table[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j][ind];
@@ -67,15 +57,13 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
-// get range data - copied from paint_range - probably could need cleanup
-            pair<int,int> cord = card_cords[ind];
+// get range data - copied initially from paint_range - probably could need cleanup
             float range_number;
             if(0 == detailViewerModel->tableStrategyModel->current_player){
-                range_number = detailViewerModel->tableStrategyModel->p1_range[cord.first][cord.second];
+                range_number = detailViewerModel->tableStrategyModel->p1_range[card1][card2];
             }else{
-                range_number = detailViewerModel->tableStrategyModel->p2_range[cord.first][cord.second];
+                range_number = detailViewerModel->tableStrategyModel->p2_range[card1][card2];
             }
-
             if(range_number < 0 || range_number > 1) throw runtime_error("range number incorrect in strategyitemdeletage");
 // got range data
 
@@ -230,17 +218,6 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
         }
         int ind = index.row() * detailViewerModel->columns + index.column();
 
-// do range data preperation - copied from paint_range - probably could need cleanup
-        vector<pair<int,int>> card_cords;
-        if(0 == detailViewerModel->tableStrategyModel->current_player ){
-            card_cords = detailViewerModel->tableStrategyModel->ui_p1_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
-        }else{
-            card_cords = detailViewerModel->tableStrategyModel->ui_p2_range[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j];
-        }
-
-// did range data preperation
-
-
         if(ind < strategy_number){
 
             pair<int,int> strategy_ui_table = detailViewerModel->tableStrategyModel->ui_strategy_table[this->detailWindowSetting->grid_i][this->detailWindowSetting->grid_j][ind];
@@ -271,13 +248,12 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
-// get range data - copied from paint_range - probably could need cleanup
-            pair<int,int> cord = card_cords[ind];
+// get range data - copied initally from paint_range - probably could need cleanup
             float range_number;
             if(0 == detailViewerModel->tableStrategyModel->current_player){
-                range_number = detailViewerModel->tableStrategyModel->p1_range[cord.first][cord.second];
+                range_number = detailViewerModel->tableStrategyModel->p1_range[card1][card2];
             }else{
-                range_number = detailViewerModel->tableStrategyModel->p2_range[cord.first][cord.second];
+                range_number = detailViewerModel->tableStrategyModel->p2_range[card1][card2];
             }
 
             if(range_number < 0 || range_number > 1) throw runtime_error("range number incorrect in strategyitemdeletage");

--- a/src/ui/strategyitemdelegate.cpp
+++ b/src/ui/strategyitemdelegate.cpp
@@ -41,7 +41,7 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
-    // get range data
+            // get range data
             vector<pair<int,int>> card_cords;
             card_cords = tableStrategyModel->ui_strategy_table[index.row()][index.column()];
             float range_number = 0;
@@ -59,10 +59,7 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
             }
             float not_in_range = 1 - range_number;
             int niR_height = (int)(not_in_range * option.rect.height());
-    //        if (withEVs) {
-    //            niR_height += (int)(1 + option.rect.height() * 0.2);
-    //        }
-    // got range data
+            // got range data
 
             int disable_height = (int)(fold_prob * (option.rect.height() - niR_height));
             int remain_height = option.rect.height() - niR_height - disable_height;
@@ -78,13 +75,11 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
             int bet_raise_num = 0;
             for(int i = 0;i < strategy.size();i ++){
                 GameActions one_action = strategy[i].first;
-//                float normalized_ev = withEVs ? normalization_tanh(this->qSolverJob->stack * 0.5, evs_without_fold[i]) : 1.;
-                float normalized_ev = withEVs ? normalization_tanh(node->getPot() * 4, evs_without_fold[i]) : 1.;
+                float normalized_ev = withEVs ? normalization_tanh(node->getPot() * 3, evs_without_fold[i]) : 1.;
                 QBrush brush(Qt::gray);
                 if(one_action.getAction() != GameTreeNode::PokerActions::FOLD){
                     if(one_action.getAction() == GameTreeNode::PokerActions::CHECK
                             || one_action.getAction() == GameTreeNode::PokerActions::CALL){
-    //                    brush = QBrush(Qt::green);
                         int green = 255;
                         int blue = max((int)(225 - normalized_ev * 175),55);
                         int red = 55;
@@ -92,8 +87,6 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
                     }
                     else if(one_action.getAction() == GameTreeNode::PokerActions::BET
                             || one_action.getAction() == GameTreeNode::PokerActions::RAISE){
-    //                    int color_base = max(128 - 32 * bet_raise_num - 1,0);
-    //                    brush = QBrush(QColor(255,color_base,color_base));
                         int color_base = max(128 - 32 * bet_raise_num - 1,0);
                         int blue = max((int)(255 - normalized_ev * (255 - color_base)), color_base);
                         int red = color_base + min((int)(normalized_ev * (255-color_base)),255-color_base);;
@@ -188,7 +181,7 @@ void StrategyItemDelegate::paint_range(QPainter *painter, const QStyleOptionView
     doc.drawContents(painter, clip);
 }
 
-void StrategyItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, bool finish) const {
+void StrategyItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {
     auto options = option;
     initStyleOption(&options, index);
     const TableStrategyModel * tableStrategyModel = qobject_cast<const TableStrategyModel*>(index.model());
@@ -210,20 +203,18 @@ void StrategyItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewIt
         int this_width = (int)((float(i + 1) / evs.size()) * options.rect.width()) - last_left;
 
         QRect rect(option.rect.left() + last_left, option.rect.top(),\
-             this_width , (int) (options.rect.height() * (finish ? 1.0 : 0.2)));
+             this_width , (int) (options.rect.height()));
         painter->fillRect(rect, brush);
         last_left += this_width;
     }
-    if (finish) {
-        QTextDocument doc;
-        doc.setHtml(options.text);
-        options.text = "";
-        //options.widget->style()->drawControl(QStyle::CE_ItemViewItem, &option, painter);
+    QTextDocument doc;
+    doc.setHtml(options.text);
+    options.text = "";
+    //options.widget->style()->drawControl(QStyle::CE_ItemViewItem, &option, painter);
 
-        painter->translate(options.rect.left(), options.rect.top());
-        QRect clip(0, 0, options.rect.width(), options.rect.height());
-        doc.drawContents(painter, clip);
-    }
+    painter->translate(options.rect.left(), options.rect.top());
+    QRect clip(0, 0, options.rect.width(), options.rect.height());
+    doc.drawContents(painter, clip);
 }
 
 void StrategyItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {

--- a/src/ui/strategyitemdelegate.cpp
+++ b/src/ui/strategyitemdelegate.cpp
@@ -47,11 +47,12 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
                 ){
             return;
         }
-        if(0 == tableStrategyModel->current_player ){
-            card_cords = tableStrategyModel->ui_p1_range[index.row()][index.column()];
-        }else{
-            card_cords = tableStrategyModel->ui_p2_range[index.row()][index.column()];
-        }
+//        if(0 == tableStrategyModel->current_player ){
+//            card_cords = tableStrategyModel->ui_p1_range[index.row()][index.column()];
+//        }else{
+//            card_cords = tableStrategyModel->ui_p2_range[index.row()][index.column()];
+//        }
+        card_cords = tableStrategyModel->ui_strategy_table[index.row()][index.column()];
 
         if(tableStrategyModel->p1_range.empty() || tableStrategyModel->p2_range.empty()){
             return;

--- a/src/ui/strategyitemdelegate.cpp
+++ b/src/ui/strategyitemdelegate.cpp
@@ -36,9 +36,10 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
                     evs_without_fold.push_back(evs[i]);
                 }
             }
-
-            for(int i = 0;i < strategy_without_fold.size();i ++){
-                strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
+            if(strategy_without_fold_sum > 0.){
+                for(int i = 0;i < strategy_without_fold.size();i ++){
+                    strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
+                }
             }
 
             // get range data

--- a/src/ui/strategyitemdelegate.cpp
+++ b/src/ui/strategyitemdelegate.cpp
@@ -58,19 +58,24 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
                 range_number = range_number / card_cords.size();
                 if(range_number < 0 || range_number > 1) throw runtime_error("range number incorrect in strategyitemdeletage");
             }
-            float not_in_range = 1 - range_number;
-            int niR_height = (int)(not_in_range * option.rect.height());
+            float not_in_range = (this->detailWindowSetting->grid_i == index.row()) &&
+                                   (this->detailWindowSetting->grid_j == index.column())
+                                    ? 0 : 1 - range_number;
+            int niR_height = (int)(not_in_range * option.rect.height() * 0.95);
             // got range data
 
-            int disable_height = (int)(fold_prob * (option.rect.height() - niR_height));
+            int disable_height = (int)(0.5+fold_prob * (option.rect.height() - niR_height));
             int remain_height = option.rect.height() - niR_height - disable_height;
 
             // draw background for flod
+        if (disable_height > 0) {
             QRect rect(option.rect.left(), option.rect.top() + niR_height,\
              option.rect.width(), disable_height);
             QBrush brush(QColor	(0,191,255));
             painter->fillRect(rect, brush);
+        }
 
+        if (remain_height > 0){
             int ind = 0;
             float last_prob = 0;
             int bet_raise_num = 0;
@@ -110,6 +115,7 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
                     ind += 1;
                 }
             }
+        }
         }
     }
     QTextDocument doc;

--- a/src/ui/tablestrategymodel.cpp
+++ b/src/ui/tablestrategymodel.cpp
@@ -346,7 +346,7 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
 
         vector<float> strategies;
 
-// get range data - initally copied from paint_range - probably could need cleanup
+        // get range data - initally copied from paint_range - could probably be integrated in loops below for efficiancy
         vector<pair<int,int>> card_cords;
         const vector<vector<float>> *current_range;
         card_cords = ui_strategy_table[i][j];
@@ -367,9 +367,7 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
         }
         else
             return ret_strategy;
-
-// got range data
-
+        // got range data
 
         if(this->ui_strategy_table[i][j].size() > 0){
             strategies = vector<float>(gameActions.size());
@@ -388,12 +386,13 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
 
             if ( range_number > 0)
                 for(int indi = 0;indi < one_strategy.size();indi ++){
-                    strategies[indi] += (one_strategy[indi] * (*current_range)[index1][index2] / range_number / strategy_number); // is this correct?
+                    strategies[indi] += (one_strategy[indi] * (*current_range)[index1][index2]);
                 }
         }
 
         for(int indi = 0;indi < strategies.size();indi ++){
-            ret_strategy.push_back(std::pair<GameActions,float>(actionNode->getActions()[indi],strategies[indi]));
+            ret_strategy.push_back(std::pair<GameActions,float>(actionNode->getActions()[indi],
+                                                                strategies[indi] / range_number / strategy_number));
         }
 
         return ret_strategy;

--- a/src/ui/tablestrategymodel.cpp
+++ b/src/ui/tablestrategymodel.cpp
@@ -349,11 +349,12 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
 // get range data - initally copied from paint_range - probably could need cleanup
         vector<pair<int,int>> card_cords;
         const vector<vector<float>> *current_range;
+        card_cords = ui_strategy_table[i][j];
         if(0 == current_player ){
-            card_cords = ui_p1_range[i][j];
+            //card_cords = ui_p1_range[i][j];
             current_range = & p1_range;
         }else{
-            card_cords = ui_p2_range[i][j];
+            //card_cords = ui_p2_range[i][j];
             current_range = & p2_range;
         }
 
@@ -393,7 +394,7 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
 
             if ( range_number > 0)
                 for(int indi = 0;indi < one_strategy.size();indi ++){
-                    strategies[indi] += (one_strategy[indi] * (*current_range)[index1][index2] / strategy_number/ range_number); // is this correct?
+                    strategies[indi] += (one_strategy[indi] * (*current_range)[index1][index2] / range_number / strategy_number); // is this correct?
                 }
         }
 

--- a/src/ui/tablestrategymodel.cpp
+++ b/src/ui/tablestrategymodel.cpp
@@ -386,13 +386,13 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
 
             if ( range_number > 0)
                 for(int indi = 0;indi < one_strategy.size();indi ++){
-                    strategies[indi] += (one_strategy[indi] * (*current_range)[index1][index2]);
+                    strategies[indi] += (one_strategy[indi] * (*current_range)[index1][index2] / range_number / strategy_number);
                 }
         }
 
         for(int indi = 0;indi < strategies.size();indi ++){
             ret_strategy.push_back(std::pair<GameActions,float>(actionNode->getActions()[indi],
-                                                                strategies[indi] / range_number / strategy_number));
+                                                                strategies[indi]));
         }
 
         return ret_strategy;

--- a/strategyexplorer.cpp
+++ b/strategyexplorer.cpp
@@ -226,6 +226,7 @@ void StrategyExplorer::onMouseMoveEvent(int i,int j){
     this->detailWindowSetting.grid_i = i;
     this->detailWindowSetting.grid_j = j;
     this->ui->detailView->viewport()->update();
+    this->ui->strategyTableView->viewport()->update();
 }
 
 void StrategyExplorer::on_strategyModeButtom_clicked()

--- a/strategyexplorer.ui
+++ b/strategyexplorer.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1154</width>
-    <height>861</height>
+    <height>721</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/strategyexplorer.ui
+++ b/strategyexplorer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1037</width>
-    <height>721</height>
+    <width>1154</width>
+    <height>861</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
Hi, first, thanks for providing the code base! Very much appreciated!

This is to improve the visualization of the results, by scaling the "Strategy" and "Strategy + EV" views with the actual range data of the current node. The range is also considered proportionally when aggregating the summary in the left table. So unlike before, actions (like fold) for hands that have been 100% folded before, do not show up any more. 
And finally, this introduces an color coding of the EV in the "Strategy + EV" views for Check/Call and Bet/Raises actions: The more negative the EV is, the more blue is added, thus indicating if something is a call is for value of for defending, or if a Bet/Raise is for Value, or a (Semi)-Bluff.

![image](https://user-images.githubusercontent.com/103132228/165771945-2c97250b-29a5-4823-9e61-34e702703f69.png)

![image](https://user-images.githubusercontent.com/103132228/165772754-8cef69c9-91f1-4be9-bdf4-2f8e971810cb.png)

Same as "strategy" view:

![image](https://user-images.githubusercontent.com/103132228/165774187-96e90eef-5178-46fe-a6b4-313fbfe788e6.png)

For cosmetics, I changed the color coding in the "EV" (only) view to transition of grey, instead of over brown. I also increased the window size of the StrategyExplorer slightly, so that on Windows the left table view is seen in total.

![image](https://user-images.githubusercontent.com/103132228/165774584-6399547b-d59c-434b-9b81-b61ce6c75c4a.png)
