### PR TITLE
Replaces int with std::size_t in for loops to prevent warnings

### DIFF
--- a/include/tools/qdebugstream.h
+++ b/include/tools/qdebugstream.h
@@ -43,7 +43,7 @@ protected:
  {
   m_string.append(p, p + n);
 
-  int pos = 0;
+  std::size_t pos = 0;
   while (pos != std::string::npos)
   {
    pos = m_string.find('\n');

--- a/include/tools/utils.h
+++ b/include/tools/utils.h
@@ -24,7 +24,7 @@ void exchange_color(vector<T>& value,vector<PrivateCards> range,int rank1,int ra
     if(value.empty())return;
     vector<int> self_ind = vector<int>(value.size());
     int privateint2ind[52 * 52 * 2] = {0};
-    for(int i = 0;i < range.size();i ++){
+    for(std::size_t i = 0;i < range.size();i ++){
         PrivateCards& pc = range[i];
         int card1 = pc.card1;
         int card2 = pc.card2;
@@ -49,9 +49,9 @@ void exchange_color(vector<T>& value,vector<PrivateCards> range,int rank1,int ra
         privateint2ind[card1 * 52 + card2] = i;
     }
 
-    for(int i = 0;i < range.size();i ++) {
+    for(std::size_t i = 0;i < range.size();i ++) {
         if(self_ind[i] == -1) continue;
-        int ind = privateint2ind[self_ind[i]];
+        std::size_t ind = privateint2ind[self_ind[i]];
         //cout << range[i].toString() << " ";
         //cout << range[ind].toString() << endl;
         if(ind != i){

--- a/src/Card.cpp
+++ b/src/Card.cpp
@@ -56,7 +56,7 @@ string Card::intCard2Str(int card){
 
 uint64_t Card::boardCards2long(vector<string> cards) {
     vector<Card> cards_objs(cards.size());
-    for(int i = 0;i < cards.size();i++){
+    for(std::size_t i = 0;i < cards.size();i++){
         cards_objs[i] = Card(cards[i]);
     }
     return Card::boardCards2long(cards_objs);
@@ -68,7 +68,7 @@ uint64_t Card::boardCard2long(Card& card){
 
 uint64_t Card::boardCards2long(vector<Card>& cards){
     std::vector<int> board_int(cards.size());
-    for(int i = 0;i < cards.size();i++){
+    for(std::size_t i = 0;i < cards.size();i++){
         board_int[i] = Card::card2int(cards[i]);
     }
     return Card::boardInts2long(board_int);
@@ -133,7 +133,7 @@ vector<int> Card::long2board(uint64_t board_long) {
 vector<Card> Card::long2boardCards(uint64_t board_long){
         vector<int> board = long2board(board_long);
         vector<Card> board_cards(board.size());
-        for(int i = 0;i < board.size();i ++){
+        for(std::size_t i = 0;i < board.size();i ++){
             int one_board = board[i];
             board_cards[i] = Card(intCard2Str(one_board));
         }
@@ -141,7 +141,7 @@ vector<Card> Card::long2boardCards(uint64_t board_long){
             throw runtime_error(tfm::format("board length not correct, board length %s",board_cards.size()));
         }
         vector<Card> retval(board_cards.size());
-        for(int i = 0;i < board_cards.size();i ++){
+        for(std::size_t i = 0;i < board_cards.size();i ++){
             retval[i] = board_cards[i];
         }
         return retval;

--- a/src/GameTree.cpp
+++ b/src/GameTree.cpp
@@ -368,7 +368,7 @@ GameTree::generateActionNode(json meta, vector<string> childrens_actions, vector
     vector<shared_ptr<GameTreeNode>> childrens;
 
     // 遍历所有children actions 来生成GameAction 的list，用于初始化ActionNode
-    for(int i = 0;i < childrens_actions.size();i++){
+    for(std::size_t i = 0;i < childrens_actions.size();i++){
         string one_action = childrens_actions[i];
         json one_children_map = childrens_nodes[i];
         if(one_action.empty()) throw runtime_error("action is null");
@@ -471,7 +471,7 @@ shared_ptr<ShowdownNode> GameTree::generateShowdownNode(json meta, string round,
 shared_ptr<TerminalNode> GameTree::generateTerminalNode(json meta, string round, shared_ptr<GameTreeNode> parent) {
     vector<double> player_payoff_list = meta["payoff"];
     vector<double> player_payoff(player_payoff_list.size());
-    for(int one_player = 0;one_player < player_payoff_list.size();one_player ++){
+    for(std::size_t one_player = 0;one_player < player_payoff_list.size();one_player ++){
 
         double tmp_payoff = player_payoff_list[one_player];
         player_payoff[one_player] = tmp_payoff;
@@ -527,7 +527,7 @@ long long GameTree::re_estimate_tree_memory(const shared_ptr<GameTreeNode>& node
         vector<GameActions> actions = action_node->getActions();
 
         long long retnum = 0;
-        for(int i = 0;i < childrens.size();i++){
+        for(std::size_t i = 0;i < childrens.size();i++){
             shared_ptr<GameTreeNode> one_child = childrens[i];
             retnum += re_estimate_tree_memory(one_child,deck_num, p1range_num, p2range_num, num_current_deal);
         }
@@ -555,7 +555,7 @@ void GameTree::recurrentPrintTree(const shared_ptr<GameTreeNode>& node, int dept
         vector<shared_ptr<GameTreeNode>> childrens = action_node->getChildrens();
         vector<GameActions> actions = action_node->getActions();
 
-        for(int i = 0;i < childrens.size();i++){
+        for(std::size_t i = 0;i < childrens.size();i++){
             shared_ptr<GameTreeNode> one_child = childrens[i];
             GameActions one_action = actions[i];
 
@@ -575,11 +575,11 @@ void GameTree::recurrentPrintTree(const shared_ptr<GameTreeNode>& node, int dept
         )) << endl;
 
         prefix += "\t";
-        for(int i = 0;i < showdown_node->get_payoffs(ShowdownNode::ShowDownResult::TIE,-1).size();i++) {
+        for(std::size_t i = 0;i < showdown_node->get_payoffs(ShowdownNode::ShowDownResult::TIE,-1).size();i++) {
             cout << (tfm::format("%sif player %s wins, payoff :", prefix,i));
             vector<double> payoffs = showdown_node->get_payoffs(ShowdownNode::ShowDownResult::NOTTIE, i);
 
-            for (int player_id = 0; player_id < payoffs.size(); player_id++) {
+            for (std::size_t player_id = 0; player_id < payoffs.size(); player_id++) {
                 cout << (
                         tfm::format(" p%s %s ", player_id, payoffs[player_id])
                 );
@@ -589,7 +589,7 @@ void GameTree::recurrentPrintTree(const shared_ptr<GameTreeNode>& node, int dept
         cout << (tfm::format("%sif Tie, payoff :", prefix));
         vector<double> payoffs = showdown_node->get_payoffs(ShowdownNode::ShowDownResult::TIE, -1);
 
-        for (int player_id = 0; player_id < payoffs.size(); player_id++) {
+        for (std::size_t player_id = 0; player_id < payoffs.size(); player_id++) {
             cout << (
                     tfm::format(" p%s %s ", player_id, payoffs[player_id])
             );
@@ -607,7 +607,7 @@ void GameTree::recurrentPrintTree(const shared_ptr<GameTreeNode>& node, int dept
         cout << (tfm::format("%sTerminal payoff :", prefix));
         vector<double> payoffs = terminal_node->get_payoffs();
 
-        for (int player_id = 0; player_id < payoffs.size(); player_id++) {
+        for (std::size_t player_id = 0; player_id < payoffs.size(); player_id++) {
             cout <<(
                     tfm::format("p%s %s ", player_id, payoffs[player_id])
             );

--- a/src/compairer/Dic5Compairer.cpp
+++ b/src/compairer/Dic5Compairer.cpp
@@ -252,7 +252,7 @@ Dic5Compairer::compair(vector<int> private_former, vector<int> private_latter, v
 
 int Dic5Compairer::getRank(vector<Card> cards) {
     vector<int> cards_int(cards.size());
-    for(int i = 0;i < cards.size();i++){
+    for(std::size_t i = 0;i < cards.size();i++){
         cards_int[i] = cards[i].getCardInt();
     }
     return this->getRank(cards_int);

--- a/src/ranges/PrivateCardsManager.cpp
+++ b/src/ranges/PrivateCardsManager.cpp
@@ -20,7 +20,7 @@ PrivateCardsManager::PrivateCardsManager(vector<vector<PrivateCards>> private_ca
     // 用一个二维数组记录每个Private Combo的对应index,方便从一方的手牌找对方的同名卡牌的index
     for(int player_id = 0;player_id < player_number;player_id ++){
         vector<PrivateCards> privateCombos = private_cards[player_id];
-        for(int i = 0;i < privateCombos.size();i ++){
+        for(std::size_t i = 0;i < privateCombos.size();i ++){
             PrivateCards one_private_combo = privateCombos[i];
             this->card_player_index[one_private_combo.hashCode()][player_id] = i;
         }
@@ -66,7 +66,7 @@ void PrivateCardsManager::setRelativeProbs() {
         int oppo = 1 - player_id;
         float player_prob_sum = 0;
 
-        for(int i = 0;i < this->private_cards[player_id].size();i ++) {
+        for(std::size_t i = 0;i < this->private_cards[player_id].size();i ++) {
             float oppo_prob_sum = 0;
             PrivateCards* player_card = &this->private_cards[player_id][i];
             uint64_t player_long = Card::boardInts2long(player_card->get_hands());
@@ -89,7 +89,7 @@ void PrivateCardsManager::setRelativeProbs() {
             player_card->relative_prob = oppo_prob_sum * player_card->weight;
             player_prob_sum += player_card->relative_prob;
         }
-        for(int i = 0;i < this->private_cards[player_id].size();i ++) {
+        for(std::size_t i = 0;i < this->private_cards[player_id].size();i ++) {
             this->private_cards[player_id][i].relative_prob = this->private_cards[player_id][i].relative_prob / player_prob_sum;
             //player_card.relative_prob = player_card.relative_prob / player_prob_sum;
         }

--- a/src/ranges/RiverRangeManager.cpp
+++ b/src/ranges/RiverRangeManager.cpp
@@ -52,7 +52,7 @@ RiverRangeManager::getRiverCombos(int player, const vector<PrivateCards> &preflo
     int index = 0;
     vector<RiverCombs> riverCombos = vector<RiverCombs>(count);
 
-    for (int hand = 0; hand < preflopCombos.size(); hand++)
+    for (std::size_t hand = 0; hand < preflopCombos.size(); hand++)
     {
         PrivateCards preflopCombo = preflopCombos[hand];
 

--- a/src/solver/BestResponse.cpp
+++ b/src/solver/BestResponse.cpp
@@ -47,7 +47,7 @@ float BestResponse::printExploitability(shared_ptr<GameTreeNode> root, int itera
         if(reach_probs[player_id].empty()) {
             reach_probs[player_id] = vector<float>(private_combos[player_id].size());
         }
-        for (int hc = 0; hc < private_combos[player_id].size(); hc++)
+        for (std::size_t hc = 0; hc < private_combos[player_id].size(); hc++)
             reach_probs[player_id][hc] = private_combos[player_id][hc].weight;
     }
 
@@ -69,7 +69,7 @@ float BestResponse::getBestReponseEv(shared_ptr<GameTreeNode> node, int player, 
     vector<PrivateCards>& player_combo = this->private_combos[player];
     vector<PrivateCards>& oppo_combo = this->private_combos[1 - player];
 
-    for(int player_hand = 0;player_hand < player_combo.size();player_hand ++){
+    for(std::size_t player_hand = 0;player_hand < player_combo.size();player_hand ++){
         float one_payoff = private_cards_evs[player_hand];
         PrivateCards& one_player_hand = (player_combo)[player_hand];
         uint64_t private_long = one_player_hand.toBoardLong();
@@ -78,7 +78,7 @@ float BestResponse::getBestReponseEv(shared_ptr<GameTreeNode> node, int player, 
         }
         float oppo_sum = 0;
 
-        for(int oppo_hand = 0;oppo_hand < oppo_combo.size();oppo_hand ++){
+        for(std::size_t oppo_hand = 0;oppo_hand < oppo_combo.size();oppo_hand ++){
             PrivateCards& one_oppo_hand = (oppo_combo)[oppo_hand];
             uint64_t private_long_oppo = one_oppo_hand.toBoardLong();
             if(Card::boardsHasIntercept(private_long,private_long_oppo)
@@ -130,7 +130,7 @@ BestResponse::chanceBestReponse(shared_ptr<ChanceNode> node, int player,const ve
     vector<vector<float>> results(node->getCards().size());
 
     #pragma omp parallel for
-    for(int card = 0;card < node->getCards().size();card ++) {
+    for(std::size_t card = 0;card < node->getCards().size();card ++) {
         shared_ptr<GameTreeNode> one_child = node->getChildren();
         Card one_card = node->getCards()[card];
         uint64_t card_long = Card::boardInt2long(one_card.getCardInt());
@@ -198,7 +198,7 @@ BestResponse::chanceBestReponse(shared_ptr<ChanceNode> node, int player,const ve
         results[one_card.getNumberInDeckInt()] = child_utility;
     }
 
-    for(int card = 0;card < node->getCards().size();card ++) {
+    for(std::size_t card = 0;card < node->getCards().size();card ++) {
         Card *one_card = const_cast<Card *>(&(node->getCards()[card]));
         vector<float> child_utility;
         int offset = this->color_iso_offset[deal][one_card->getCardInt() % 4];
@@ -220,7 +220,7 @@ BestResponse::chanceBestReponse(shared_ptr<ChanceNode> node, int player,const ve
 #ifdef DEBUG
         if(child_utility.size() != chance_utility.size()) throw runtime_error("length not match3 ");
 #endif
-        for(int i = 0;i < child_utility.size();i ++)
+        for(std::size_t i = 0;i < child_utility.size();i ++)
             chance_utility[i] += (child_utility)[i];
     }
 
@@ -242,7 +242,7 @@ BestResponse::actionBestResponse(shared_ptr<ActionNode> node, int player, const 
                 my_exploitability.assign(node_ev.begin(),node_ev.end());
                 first_action_flag = false;
             }else {
-                for (int i = 0;i < node_ev.size();i ++) {
+                for (std::size_t i = 0;i < node_ev.size();i ++) {
                     my_exploitability[i] = max(my_exploitability[i],node_ev[i]);
                 }
             }
@@ -273,7 +273,7 @@ BestResponse::actionBestResponse(shared_ptr<ActionNode> node, int player, const 
 
         vector<vector<vector<float>>> best_respond_arr_new_reach_probs = vector<vector<vector<float>>>(node->getChildrens().size());
         // 构造reach probs矩阵
-        for(int action_ind = 0;action_ind < node->getChildrens().size();action_ind ++){
+        for(std::size_t action_ind = 0;action_ind < node->getChildrens().size();action_ind ++){
             if(best_respond_arr_new_reach_probs[action_ind].empty()){
                 best_respond_arr_new_reach_probs[action_ind] = vector<vector<float>>(this->player_number);
             }
@@ -314,7 +314,7 @@ BestResponse::actionBestResponse(shared_ptr<ActionNode> node, int player, const 
                 );
 #endif
 
-            for(int i = 0 ;i < total_payoffs.size();i ++){
+            for(std::size_t i = 0 ;i < total_payoffs.size();i ++){
                 total_payoffs[i] += action_payoffs[i];//  * node_strategy[i] 的动作实际上已经在递归的时候做过了，所以这里不需要乘
             }
         }
@@ -350,7 +350,7 @@ BestResponse::terminalBestReponse(shared_ptr<TerminalNode> node, int player, con
     float oppo_prob_sum = 0;
 
     const vector<float>& oppo_reach_prob = reach_probs[1 - player];
-    for(int oppo_hand = 0;oppo_hand < oppo_combs.size(); oppo_hand ++){
+    for(std::size_t oppo_hand = 0;oppo_hand < oppo_combs.size(); oppo_hand ++){
         const RiverCombs& one_hc = oppo_combs[oppo_hand];
         uint64_t one_hc_long  = Card::boardInts2long(one_hc.private_cards.get_hands());
 
@@ -365,7 +365,7 @@ BestResponse::terminalBestReponse(shared_ptr<TerminalNode> node, int player, con
     }
 
 
-    for(int player_hand = 0;player_hand < player_combs.size();player_hand ++) {
+    for(std::size_t player_hand = 0;player_hand < player_combs.size();player_hand ++) {
         const RiverCombs& player_hc = player_combs[player_hand];
         uint64_t player_hc_long = Card::boardInts2long(player_hc.private_cards.get_hands());
         if(Card::boardsHasIntercept(player_hc_long,board_long)){
@@ -413,12 +413,12 @@ BestResponse::showdownBestResponse(shared_ptr<ShowdownNode> node, int player,con
     // 计算胜利时的payoff
     float winsum = 0;
     vector<float> card_winsum(52);
-    for(int i = 0;i < card_winsum.size();i ++) card_winsum[i] = 0;
+    for(std::size_t i = 0;i < card_winsum.size();i ++) card_winsum[i] = 0;
 
-    int j = 0;
+    std::size_t j = 0;
     //if(player_combs.length != oppo_combs.length) throw new RuntimeException("");
 
-    for(int i = 0;i < player_combs.size();i ++){
+    for(std::size_t i = 0;i < player_combs.size();i ++){
         const RiverCombs& one_player_comb = player_combs[i];
         while (j < oppo_combs.size() && one_player_comb.rank < oppo_combs[j].rank){
             const RiverCombs& one_oppo_comb = oppo_combs[j];

--- a/src/solver/PCfrSolver.cpp
+++ b/src/solver/PCfrSolver.cpp
@@ -86,7 +86,7 @@ vector<vector<float>> PCfrSolver::getReachProbs() {
     for(int player = 0;player < this->player_number;player ++){
         vector<PrivateCards> player_cards = this->playerHands(player);
         vector<float> reach_prob(player_cards.size());
-        for(int i = 0;i < player_cards.size();i ++){
+        for(std::size_t i = 0;i < player_cards.size();i ++){
             reach_prob[i] = player_cards[i].weight;
         }
         retval[player] = reach_prob;
@@ -288,7 +288,7 @@ PCfrSolver::chanceUtility(int player, shared_ptr<ChanceNode> node, const vector<
     vector<int> valid_cards;
     valid_cards.reserve(node->getCards().size());
 
-    for(int card = 0;card < node->getCards().size();card ++) {
+    for(std::size_t card = 0;card < node->getCards().size();card ++) {
         shared_ptr<GameTreeNode> one_child = node->getChildren();
         Card *one_card = const_cast<Card *>(&(node->getCards()[card]));
         uint64_t card_long = Card::boardInt2long(one_card->getCardInt());//Card::boardCards2long(new Card[]{one_card});
@@ -299,7 +299,7 @@ PCfrSolver::chanceUtility(int player, shared_ptr<ChanceNode> node, const vector<
     }
 
     #pragma omp parallel for schedule(static)
-    for(int valid_ind = 0;valid_ind < valid_cards.size();valid_ind++) {
+    for(std::size_t valid_ind = 0;valid_ind < valid_cards.size();valid_ind++) {
         int card = valid_cards[valid_ind];
         shared_ptr<GameTreeNode> one_child = node->getChildren();
         Card *one_card = const_cast<Card *>(&(node->getCards()[card]));
@@ -363,7 +363,7 @@ PCfrSolver::chanceUtility(int player, shared_ptr<ChanceNode> node, const vector<
         }
     }
 
-    for(int card = 0;card < node->getCards().size();card ++) {
+    for(std::size_t card = 0;card < node->getCards().size();card ++) {
         Card *one_card = const_cast<Card *>(&(node->getCards()[card]));
         vector<float> child_utility;
         int offset = this->color_iso_offset[deal][one_card->getCardInt() % 4];
@@ -385,10 +385,10 @@ PCfrSolver::chanceUtility(int player, shared_ptr<ChanceNode> node, const vector<
         if(child_utility.size() != chance_utility.size()) throw runtime_error("length not match");
 #endif
         if(iter > this->warmup) {
-            for (int i = 0; i < child_utility.size(); i++)
+            for (std::size_t i = 0; i < child_utility.size(); i++)
                 chance_utility[i] += child_utility[i];
         }else{
-            for (int i = 0; i < child_utility.size(); i++)
+            for (std::size_t i = 0; i < child_utility.size(); i++)
                 chance_utility[i] += child_utility[i] * multiplier[card];
         }
     }
@@ -454,11 +454,11 @@ PCfrSolver::actionUtility(int player, shared_ptr<ActionNode> node, const vector<
     int node_player = node->getPlayer();
 
     vector<vector<float>> results(actions.size());
-    for (int action_id = 0; action_id < actions.size(); action_id++) {
+    for (std::size_t action_id = 0; action_id < actions.size(); action_id++) {
 
         if (node_player != player) {
             vector<float> new_reach_prob = vector<float>(reach_probs.size());
-            for (int hand_id = 0; hand_id < new_reach_prob.size(); hand_id++) {
+            for (std::size_t hand_id = 0; hand_id < new_reach_prob.size(); hand_id++) {
                 float strategy_prob = current_strategy[hand_id + action_id * node_player_private_cards.size()];
                 new_reach_prob[hand_id] = reach_probs[hand_id] * strategy_prob;
             }
@@ -474,7 +474,7 @@ PCfrSolver::actionUtility(int player, shared_ptr<ActionNode> node, const vector<
     }
 
     //#pragma omp taskwait
-    for (int action_id = 0; action_id < actions.size(); action_id++) {
+    for (std::size_t action_id = 0; action_id < actions.size(); action_id++) {
         vector<float> action_utilities = results[action_id];
         if(action_utilities.empty()){
             continue;
@@ -496,7 +496,7 @@ PCfrSolver::actionUtility(int player, shared_ptr<ActionNode> node, const vector<
         }
 #endif
 
-        for (int hand_id = 0; hand_id < action_utilities.size(); hand_id++) {
+        for (std::size_t hand_id = 0; hand_id < action_utilities.size(); hand_id++) {
             if (player == node->getPlayer()) {
                 float strategy_prob = current_strategy[hand_id + action_id * node_player_private_cards.size()];
                 payoffs[hand_id] += strategy_prob * (action_utilities)[hand_id];
@@ -508,9 +508,9 @@ PCfrSolver::actionUtility(int player, shared_ptr<ActionNode> node, const vector<
 
 
     if (player == node->getPlayer()) {
-        for (int i = 0; i < node_player_private_cards.size(); i++) {
+        for (std::size_t i = 0; i < node_player_private_cards.size(); i++) {
             //boolean regrets_all_negative = true;
-            for (int action_id = 0; action_id < actions.size(); action_id++) {
+            for (std::size_t action_id = 0; action_id < actions.size(); action_id++) {
                 // 下面是regret计算的伪代码
                 // regret[action_id * player_hc: (action_id + 1) * player_hc]
                 //     = all_action_utilitiy[action_id] - payoff[action_id]
@@ -549,7 +549,7 @@ PCfrSolver::actionUtility(int player, shared_ptr<ActionNode> node, const vector<
             fill(oppo_card_sum.begin(),oppo_card_sum.end(),0);
 
             const vector<PrivateCards>& oppo_hand = playerHands(oppo);
-            for(int i = 0;i < oppo_hand.size();i ++){
+            for(std::size_t i = 0;i < oppo_hand.size();i ++){
                 oppo_card_sum[oppo_hand[i].card1] += reach_probs[i];
                 oppo_card_sum[oppo_hand[i].card2] += reach_probs[i];
                 oppo_sum += reach_probs[i];
@@ -557,8 +557,8 @@ PCfrSolver::actionUtility(int player, shared_ptr<ActionNode> node, const vector<
 
             const vector<PrivateCards>& player_hand = playerHands(player);
             vector<float> evs(actions.size() * node_player_private_cards.size(),0.0);
-            for (int action_id = 0; action_id < actions.size(); action_id++) {
-                for (int hand_id = 0; hand_id < node_player_private_cards.size(); hand_id++) {
+            for (std::size_t action_id = 0; action_id < actions.size(); action_id++) {
+                for (std::size_t hand_id = 0; hand_id < node_player_private_cards.size(); hand_id++) {
                     float one_ev = (all_action_utility)[action_id][hand_id];//current_strategy; //[hand_id + action_id * node_player_private_cards.size()];
 
                     int oppo_same_card_ind = this->pcm.indPlayer2Player(player,oppo,hand_id);
@@ -607,8 +607,8 @@ PCfrSolver::showdownUtility(int player, shared_ptr<ShowdownNode> node, const vec
     vector<float> card_winsum = vector<float> (52);//node->card_sum;
     fill(card_winsum.begin(),card_winsum.end(),0);
 
-    int j = 0;
-    for(int i = 0;i < player_combs.size();i ++){
+    std::size_t j = 0;
+    for(std::size_t i = 0;i < player_combs.size();i ++){
         const RiverCombs& one_player_comb = player_combs[i];
         while (j < oppo_combs.size() && one_player_comb.rank < oppo_combs[j].rank){
             const RiverCombs& one_oppo_comb = oppo_combs[j];
@@ -661,13 +661,13 @@ PCfrSolver::terminalUtility(int player, shared_ptr<TerminalNode> node, const vec
     vector<float> oppo_card_sum = vector<float> (52);
     fill(oppo_card_sum.begin(),oppo_card_sum.end(),0);
 
-    for(int i = 0;i < oppo_hand.size();i ++){
+    for(std::size_t i = 0;i < oppo_hand.size();i ++){
         oppo_card_sum[oppo_hand[i].card1] += reach_prob[i];
         oppo_card_sum[oppo_hand[i].card2] += reach_prob[i];
         oppo_sum += reach_prob[i];
     }
 
-    for(int i = 0;i < player_hand.size();i ++){
+    for(std::size_t i = 0;i < player_hand.size();i ++){
         const PrivateCards& one_player_hand = player_hand[i];
         if(Card::boardsHasIntercept(current_board,Card::boardInts2long(one_player_hand.get_hands()))){
             continue;
@@ -694,7 +694,7 @@ void PCfrSolver::findGameSpecificIsomorphisms() {
     vector<Card> board_cards = Card::long2boardCards(this->initial_board_long);
     for(int i = 0;i <= 1;i ++){
         vector<PrivateCards>& range = i == 0?this->range1:this->range2;
-        for(int i_range = 0;i_range < range.size();i_range ++) {
+        for(std::size_t i_range = 0;i_range < range.size();i_range ++) {
             PrivateCards one_range = range[i_range];
             uint32_t range_hash[4]; // four colors, hash of the isomorphisms range + hand combos
             for(int i = 0;i < 4;i ++)range_hash[i] = 0;
@@ -733,7 +733,7 @@ void PCfrSolver::findGameSpecificIsomorphisms() {
             }
         }
     }
-    for(int deal = 0;deal < this->deck.getCards().size();deal ++) {
+    for(std::size_t deal = 0;deal < this->deck.getCards().size();deal ++) {
         uint16_t color_hash[4];
         for(int i = 0;i < 4;i ++)color_hash[i] = 0;
         // chance node isomorphisms
@@ -853,7 +853,7 @@ void PCfrSolver::exchangeRange(json& strategy,int rank1,int rank2,shared_ptr<Act
     vector<string> range_strs;
     vector<vector<float>> strategies;
 
-    for(int i = 0;i < this->ranges[player].size();i ++){
+    for(std::size_t i = 0;i < this->ranges[player].size();i ++){
         string one_range_str = this->ranges[player][i].toString();
         if(!strategy.contains(one_range_str)){
             for(auto one_key:strategy.items()){
@@ -868,7 +868,7 @@ void PCfrSolver::exchangeRange(json& strategy,int rank1,int rank2,shared_ptr<Act
     }
     exchange_color(strategies,this->ranges[player],rank1,rank2);
 
-    for(int i = 0;i < this->ranges[player].size();i ++) {
+    for(std::size_t i = 0;i < this->ranges[player].size();i ++) {
         string one_range_str = this->ranges[player][i].toString();
         vector<float> one_strategy = strategies[i];
         strategy[one_range_str] = one_strategy;
@@ -897,7 +897,7 @@ void PCfrSolver::reConvertJson(const shared_ptr<GameTreeNode>& node,json& strate
         (*retval)["childrens"] = json();
         json& childrens = (*retval)["childrens"];
 
-        for(int i = 0;i < one_node->getActions().size();i ++){
+        for(std::size_t i = 0;i < one_node->getActions().size();i ++){
             GameActions& one_action = one_node->getActions()[i];
             shared_ptr<GameTreeNode> one_child = one_node->getChildrens()[i];
             vector<string> new_prefix(prefix);
@@ -938,17 +938,17 @@ void PCfrSolver::reConvertJson(const shared_ptr<GameTreeNode>& node,json& strate
             card_strs.push_back(card.toString());
 
         json& dealcards = (*retval)["dealcards"];
-        for(int i = 0;i < cards.size();i ++){
+        for(std::size_t i = 0;i < cards.size();i ++){
             vector<vector<int>> new_exchange_color_list(exchange_color_list);
             Card& one_card = const_cast<Card &>(cards[i]);
             vector<string> new_prefix(prefix);
             new_prefix.push_back("Chance:" + one_card.toString());
 
-            int card = i;
+            std::size_t card = i;
 
             int offset = this->color_iso_offset[deal][one_card.getCardInt() % 4];
             if(offset < 0) {
-                for(int x = 0;x < cards.size();x ++){
+                for(std::size_t x = 0;x < cards.size();x ++){
                     if(
                             Card::card2int(cards[x]) ==
                             (Card::card2int(cards[card]) + offset)
@@ -1028,7 +1028,7 @@ vector<vector<vector<float>>> PCfrSolver::get_strategy(shared_ptr<ActionNode> no
         int card = one_card.getNumberInDeckInt();
         int offset = this->color_iso_offset[deal][one_card.getCardInt() % 4];
         if(offset < 0) {
-            for(int x = 0;x < cards.size();x ++){
+            for(std::size_t x = 0;x < cards.size();x ++){
                 if(
                     Card::card2int(cards[x]) ==
                     (Card::card2int(cards[card]) + offset)
@@ -1068,7 +1068,7 @@ vector<vector<vector<float>>> PCfrSolver::get_strategy(shared_ptr<ActionNode> no
     int player = node->getPlayer();
 
     json& strategy = retjson["strategy"];
-    for(int i = 0;i < this->ranges[player].size();i ++){
+    for(std::size_t i = 0;i < this->ranges[player].size();i ++){
         PrivateCards pc = this->ranges[player][i];
         string one_range_str = pc.toString();
         if(!strategy.contains(one_range_str)){
@@ -1112,7 +1112,7 @@ vector<vector<vector<float>>> PCfrSolver::get_evs(shared_ptr<ActionNode> node,ve
         int card = one_card.getNumberInDeckInt();
         int offset = this->color_iso_offset[deal][one_card.getCardInt() % 4];
         if(offset < 0) {
-            for(int x = 0;x < cards.size();x ++){
+            for(std::size_t x = 0;x < cards.size();x ++){
                 if(
                     Card::card2int(cards[x]) ==
                     (Card::card2int(cards[card]) + offset)
@@ -1152,7 +1152,7 @@ vector<vector<vector<float>>> PCfrSolver::get_evs(shared_ptr<ActionNode> node,ve
     int player = node->getPlayer();
 
     json& evs = retjson["evs"];
-    for(int i = 0;i < this->ranges[player].size();i ++){
+    for(std::size_t i = 0;i < this->ranges[player].size();i ++){
         PrivateCards pc = this->ranges[player][i];
         string one_range_str = pc.toString();
         if(!evs.contains(one_range_str)){

--- a/src/tools/CommandLineTool.cpp
+++ b/src/tools/CommandLineTool.cpp
@@ -136,7 +136,7 @@ void CommandLineTool::processCommand(string input) {
 
         if(bet_type == "bet" || bet_type == "raise" || bet_type == "donk"){
             sizes->clear();
-            for(int i = 3;i < params.size();i ++ ){
+            for(std::size_t i = 3;i < params.size();i ++ ){
                 sizes->push_back(stof(params[i]));
             }
         }

--- a/src/tools/PrivateRangeConverter.cpp
+++ b/src/tools/PrivateRangeConverter.cpp
@@ -43,10 +43,10 @@ vector<PrivateCards> PrivateRangeConverter::rangeStr2Cards(string range_str, vec
                 char rank2 = one_range.at(1);
 
                 vector<string> suits = Card::getSuits();
-                for(int i = 0;i < suits.size();i++){
+                for(std::size_t i = 0;i < suits.size();i++){
                     string one_suit = suits[i];
                     int begin_index = rank1 == rank2 ? i:0;
-                    for(int j = begin_index;j < suits.size();j++){
+                    for(std::size_t j = begin_index;j < suits.size();j++){
                         string another_suit = suits[j];
                         if(one_suit == another_suit){
                             continue;
@@ -70,10 +70,10 @@ vector<PrivateCards> PrivateRangeConverter::rangeStr2Cards(string range_str, vec
             char rank1 = one_range.at(0);
             char rank2 = one_range.at(1);
             vector<string> suits = Card::getSuits();
-            for(int i = 0;i < suits.size();i++){
+            for(std::size_t i = 0;i < suits.size();i++){
                 string one_suit = suits[i];
                 int begin_index = rank1 == rank2 ? i:0;
-                for(int j = begin_index;j < suits.size();j++){
+                for(std::size_t j = begin_index;j < suits.size();j++){
                     string another_suit = suits[j];
                     if(one_suit == another_suit && rank1 == rank2){
                         continue;
@@ -95,8 +95,8 @@ vector<PrivateCards> PrivateRangeConverter::rangeStr2Cards(string range_str, vec
     }
 
     // 排除初试range中重复的情况
-    for(int i = 0;i < private_cards.size();i ++){
-        for(int j = i + 1;j < private_cards.size();j ++) {
+    for(std::size_t i = 0;i < private_cards.size();i ++){
+        for(std::size_t j = i + 1;j < private_cards.size();j ++) {
             PrivateCards one_cards = private_cards[i];
             PrivateCards another_cards = private_cards[j];
             if (one_cards.card1 == another_cards.card1 && one_cards.card2 == another_cards.card2){
@@ -115,7 +115,7 @@ vector<PrivateCards> PrivateRangeConverter::rangeStr2Cards(string range_str, vec
     }
 
     vector<PrivateCards> private_cards_list(private_cards.size());
-    for(int i = 0;i < private_cards.size();i ++){
+    for(std::size_t i = 0;i < private_cards.size();i ++){
         private_cards_list[i] = private_cards[i];
         //System.out.print(String.format("[%s-%s]",Card.intCard2Str(private_cards_list[i].card1),Card.intCard2Str(private_cards_list[i].card2)));
     }

--- a/src/trainable/DiscountedCfrTrainable.cpp
+++ b/src/trainable/DiscountedCfrTrainable.cpp
@@ -83,7 +83,7 @@ const vector<float> DiscountedCfrTrainable::getcurrentStrategyNoCache() {
 
 void DiscountedCfrTrainable::setEv(const vector<float>& evs){
     if(evs.size() != this->evs.size()) throw runtime_error("size mismatch in discountcfrtrainable setEV");
-    for(int i = 0;i < evs.size();i ++) if(evs[i] == evs[i])this->evs[i] = evs[i];
+    for(std::size_t i = 0;i < evs.size();i ++) if(evs[i] == evs[i])this->evs[i] = evs[i];
 }
 
 void DiscountedCfrTrainable::updateRegrets(const vector<float>& regrets, int iteration_number, const vector<float>& reach_probs) {
@@ -143,12 +143,12 @@ json DiscountedCfrTrainable::dump_strategy(bool with_state) {
         );
     }
 
-    for(int i = 0;i < this->privateCards->size();i ++){
+    for(std::size_t i = 0;i < this->privateCards->size();i ++){
         PrivateCards& one_private_card = (*this->privateCards)[i];
         vector<float> one_strategy(this->action_number);
 
         for(int j = 0;j < this->action_number;j ++){
-            int strategy_index = j * this->privateCards->size() + i;
+            std::size_t strategy_index = j * this->privateCards->size() + i;
             one_strategy[j] = average_strategy[strategy_index];
         }
         strategy[tfm::format("%s",one_private_card.toString())] = one_strategy;
@@ -171,12 +171,12 @@ json DiscountedCfrTrainable::dump_evs() {
         );
     }
 
-    for(int i = 0;i < this->privateCards->size();i ++){
+    for(std::size_t i = 0;i < this->privateCards->size();i ++){
         PrivateCards& one_private_card = (*this->privateCards)[i];
         vector<float> one_evs(this->action_number);
 
         for(int j = 0;j < this->action_number;j ++){
-            int evs_index = j * this->privateCards->size() + i;
+            std::size_t evs_index = j * this->privateCards->size() + i;
             one_evs[j] = average_evs[evs_index];
         }
         evs[tfm::format("%s",one_private_card.toString())] = one_evs;

--- a/src/trainable/DiscountedCfrTrainableHF.cpp
+++ b/src/trainable/DiscountedCfrTrainableHF.cpp
@@ -90,7 +90,7 @@ const vector<float> DiscountedCfrTrainableHF::getcurrentStrategyNoCache() {
 
 void DiscountedCfrTrainableHF::setEv(const vector<float>& evs){
     if(evs.size() != this->evs.size()) throw runtime_error("size mismatch in discountcfrtrainable setEV");
-    for(int i = 0;i < evs.size();i ++) if(evs[i] == evs[i])this->evs[i] = evs[i];
+    for(std::size_t i = 0;i < evs.size();i ++) if(evs[i] == evs[i])this->evs[i] = evs[i];
 }
 
 void DiscountedCfrTrainableHF::updateRegrets(const vector<float>& regrets, int iteration_number, const vector<float>& reach_probs) {
@@ -165,7 +165,7 @@ json DiscountedCfrTrainableHF::dump_strategy(bool with_state) {
         );
     }
 
-    for(int i = 0;i < this->privateCards->size();i ++){
+    for(std::size_t i = 0;i < this->privateCards->size();i ++){
         PrivateCards& one_private_card = (*this->privateCards)[i];
         vector<float> one_strategy(this->action_number);
 
@@ -193,7 +193,7 @@ json DiscountedCfrTrainableHF::dump_evs() {
         );
     }
 
-    for(int i = 0;i < this->privateCards->size();i ++){
+    for(std::size_t i = 0;i < this->privateCards->size();i ++){
         PrivateCards& one_private_card = (*this->privateCards)[i];
         vector<float> one_evs(this->action_number);
 

--- a/src/trainable/DiscountedCfrTrainableSF.cpp
+++ b/src/trainable/DiscountedCfrTrainableSF.cpp
@@ -84,7 +84,7 @@ const vector<float> DiscountedCfrTrainableSF::getcurrentStrategyNoCache() {
 
 void DiscountedCfrTrainableSF::setEv(const vector<float>& evs){
     if(evs.size() != this->evs.size()) throw runtime_error("size mismatch in discountcfrtrainable setEV");
-    for(int i = 0;i < evs.size();i ++) if(evs[i] == evs[i])this->evs[i] = evs[i];
+    for(std::size_t i = 0;i < evs.size();i ++) if(evs[i] == evs[i])this->evs[i] = evs[i];
 }
 
 void DiscountedCfrTrainableSF::updateRegrets(const vector<float>& regrets, int iteration_number, const vector<float>& reach_probs) {
@@ -157,12 +157,12 @@ json DiscountedCfrTrainableSF::dump_strategy(bool with_state) {
         );
     }
 
-    for(int i = 0;i < this->privateCards->size();i ++){
+    for(std::size_t i = 0;i < this->privateCards->size();i ++){
         PrivateCards& one_private_card = (*this->privateCards)[i];
         vector<float> one_strategy(this->action_number);
 
         for(int j = 0;j < this->action_number;j ++){
-            int strategy_index = j * this->privateCards->size() + i;
+            std::size_t strategy_index = j * this->privateCards->size() + i;
             one_strategy[j] = average_strategy[strategy_index];
         }
         strategy[tfm::format("%s",one_private_card.toString())] = one_strategy;
@@ -185,12 +185,12 @@ json DiscountedCfrTrainableSF::dump_evs() {
         );
     }
 
-    for(int i = 0;i < this->privateCards->size();i ++){
+    for(std::size_t i = 0;i < this->privateCards->size();i ++){
         PrivateCards& one_private_card = (*this->privateCards)[i];
         vector<float> one_evs(this->action_number);
 
         for(int j = 0;j < this->action_number;j ++){
-            int evs_index = j * this->privateCards->size() + i;
+            std::size_t evs_index = j * this->privateCards->size() + i;
             one_evs[j] = average_evs[evs_index];
         }
         evs[tfm::format("%s",one_private_card.toString())] = one_evs;

--- a/src/ui/detailitemdelegate.cpp
+++ b/src/ui/detailitemdelegate.cpp
@@ -43,7 +43,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
             float fold_prob = 0;
             vector<float> strategy_without_fold;
             float strategy_without_fold_sum = 0;
-            for(int i = 0;i < strategy.size();i ++){
+            for(std::size_t i = 0;i < strategy.size();i ++){
                 GameActions one_action = gameActions[i];
                 if(one_action.getAction() == GameTreeNode::PokerActions::FOLD){
                     fold_prob = strategy[i];
@@ -53,7 +53,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
                 }
             }
 
-            for(int i = 0;i < strategy_without_fold.size();i ++){
+            for(std::size_t i = 0;i < strategy_without_fold.size();i ++){
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
@@ -84,7 +84,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
             int ind = 0;
             float last_prob = 0;
             int bet_raise_num = 0;
-            for(int i = 0;i < strategy.size();i ++){
+            for(std::size_t i = 0;i < strategy.size();i ++){
                 GameActions one_action = gameActions[i];
                 QBrush brush(Qt::gray);
                 if(one_action.getAction() != GameTreeNode::PokerActions::FOLD){
@@ -117,7 +117,7 @@ void DetailItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionVie
             options.text += detailViewerModel->tableStrategyModel->cardint2card[card1].toFormattedHtml();
             options.text += detailViewerModel->tableStrategyModel->cardint2card[card2].toFormattedHtml();
             options.text = "<h2 >" + options.text + "<\/h2>";
-            for(int i = 0;i < strategy.size();i ++){
+            for(std::size_t i = 0;i < strategy.size();i ++){
                 GameActions one_action = gameActions[i];
                 float one_strategy = strategy[i] * 100;
                 if(one_action.getAction() ==  GameTreeNode::PokerActions::FOLD){
@@ -237,7 +237,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
             float fold_prob = 0;
             vector<float> strategy_without_fold;
             float strategy_without_fold_sum = 0;
-            for(int i = 0;i < strategy.size();i ++){
+            for(std::size_t i = 0;i < strategy.size();i ++){
                 GameActions one_action = gameActions[i];
                 if(one_action.getAction() == GameTreeNode::PokerActions::FOLD){
                     fold_prob = strategy[i];
@@ -247,7 +247,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
                 }
             }
 
-            for(int i = 0;i < strategy_without_fold.size();i ++){
+            for(std::size_t i = 0;i < strategy_without_fold.size();i ++){
                 strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
             }
 
@@ -279,7 +279,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
             int ind = 0;
             float last_prob = 0;
             int bet_raise_num = 0;
-            for(int i = 0;i < strategy.size();i ++){
+            for(std::size_t i = 0;i < strategy.size();i ++){
                 GameActions one_action = gameActions[i];
                 float normalized_ev = normalization_tanh(node->getPot() * 3,evs[i]);
                 QBrush brush(Qt::gray);
@@ -321,7 +321,7 @@ void DetailItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewItem
             options.text += detailViewerModel->tableStrategyModel->cardint2card[card1].toFormattedHtml();
             options.text += detailViewerModel->tableStrategyModel->cardint2card[card2].toFormattedHtml();
             options.text = "<h2>" + options.text + "<\/h2>";
-            for(int i = 0;i < evs.size();i ++){
+            for(std::size_t i = 0;i < evs.size();i ++){
                 GameActions one_action = gameActions[i];
                 QString one_ev = evs[i] != evs[i]? tr("Can't calculate"):QString::number(evs[i],'f',1);
                 QString ev_str = tr("EV");
@@ -373,7 +373,7 @@ void DetailItemDelegate::paint_evs_only(QPainter *painter, const QStyleOptionVie
         }
 
         vector<float> evs = detailViewerModel->tableStrategyModel->get_ev_grid(this->detailWindowSetting->grid_i,this->detailWindowSetting->grid_j);
-        int ind = index.row() * detailViewerModel->columns + index.column();
+        std::size_t ind = index.row() * detailViewerModel->columns + index.column();
 
         if(ind < evs.size() and ind < strategy_number)
         {

--- a/src/ui/roughstrategyviewermodel.cpp
+++ b/src/ui/roughstrategyviewermodel.cpp
@@ -40,7 +40,7 @@ int RoughStrategyViewerModel::rowCount(const QModelIndex &parent) const
 
 QVariant RoughStrategyViewerModel::data(const QModelIndex &index, int role) const
 {
-    int col = index.column();
+    std::size_t col = index.column();
     if(col < this->tableStrategyModel->total_strategy.size()){
         pair<GameActions,pair<float,float>> one_strategy = this->tableStrategyModel->total_strategy[col];
         return QString::number(one_strategy.second.second);

--- a/src/ui/strategyitemdelegate.cpp
+++ b/src/ui/strategyitemdelegate.cpp
@@ -26,7 +26,7 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
             vector<float> strategy_without_fold;
             vector<float> evs_without_fold;
             float strategy_without_fold_sum = 0;
-            for(int i = 0;i < strategy.size();i ++){
+            for(std::size_t i = 0;i < strategy.size();i ++){
                 GameActions one_action = strategy[i].first;
                 if(one_action.getAction() == GameTreeNode::PokerActions::FOLD){
                     fold_prob = strategy[i].second;
@@ -37,7 +37,7 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
                 }
             }
             if(strategy_without_fold_sum > 0.){
-                for(int i = 0;i < strategy_without_fold.size();i ++){
+                for(std::size_t i = 0;i < strategy_without_fold.size();i ++){
                     strategy_without_fold[i] = strategy_without_fold[i] / strategy_without_fold_sum;
                 }
             }
@@ -79,7 +79,7 @@ void StrategyItemDelegate::paint_strategy(QPainter *painter, const QStyleOptionV
             int ind = 0;
             float last_prob = 0;
             int bet_raise_num = 0;
-            for(int i = 0;i < strategy.size();i ++){
+            for(std::size_t i = 0;i < strategy.size();i ++){
                 GameActions one_action = strategy[i].first;
                 float normalized_ev = withEVs ? normalization_tanh(node->getPot() * 3, evs_without_fold[i]) : 1.;
                 QBrush brush(Qt::gray);
@@ -196,7 +196,7 @@ void StrategyItemDelegate::paint_evs(QPainter *painter, const QStyleOptionViewIt
     sort(evs.begin(), evs.end());
 
     int last_left = 0;
-    for(int i = 0;i < evs.size();i ++ ){
+    for(std::size_t i = 0;i < evs.size();i ++ ){
         float one_ev = evs[evs.size() - i - 1];
         float normalized_ev = normalization_tanh(this->qSolverJob->stack,one_ev);
         //options.text += QString("</br>%1").arg(QString::number(normalized_ev));

--- a/src/ui/tablestrategymodel.cpp
+++ b/src/ui/tablestrategymodel.cpp
@@ -66,41 +66,41 @@ void TableStrategyModel::setupModelData()
     }
 
     this->ui_strategy_table = vector<vector<vector<pair<int,int>>>>(ranks.size());
-    for(int i = 0;i < ranks.size();i ++){
+    for(std::size_t i = 0;i < ranks.size();i ++){
         this->ui_strategy_table[i] = vector<vector<pair<int,int>>>(ranks.size());
-        for(int j = 0;j < ranks.size();j ++){
+        for(std::size_t j = 0;j < ranks.size();j ++){
             this->ui_strategy_table[i][j] = vector<pair<int,int>>();
         }
     }
 
     this->p1_range = vector<vector<float>>(52);
-    for(int i = 0;i < 52;i ++){
+    for(std::size_t i = 0;i < 52;i ++){
         this->p1_range[i] = vector<float>(52);
-        for(int j = 0;j < 52;j ++){
+        for(std::size_t j = 0;j < 52;j ++){
             this->p1_range[i][j] = 0;
         }
     }
 
     this->p2_range = vector<vector<float>>(52);
-    for(int i = 0;i < 52;i ++){
+    for(std::size_t i = 0;i < 52;i ++){
         this->p2_range[i] = vector<float>(52);
-        for(int j = 0;j < 52;j ++){
+        for(std::size_t j = 0;j < 52;j ++){
             this->p2_range[i][j] = 0;
         }
     }
 
     this->ui_p1_range = vector<vector<vector<pair<int,int>>>>(ranks.size());
-    for(int i = 0;i < ranks.size();i ++){
+    for(std::size_t i = 0;i < ranks.size();i ++){
         this->ui_p1_range[i] = vector<vector<pair<int,int>>>(ranks.size());
-        for(int j = 0;j < ranks.size();j ++){
+        for(std::size_t j = 0;j < ranks.size();j ++){
             this->ui_p1_range[i][j] = vector<pair<int,int>>();
         }
     }
 
     this->ui_p2_range = vector<vector<vector<pair<int,int>>>>(ranks.size());
-    for(int i = 0;i < ranks.size();i ++){
+    for(std::size_t i = 0;i < ranks.size();i ++){
         this->ui_p2_range[i] = vector<vector<pair<int,int>>>(ranks.size());
-        for(int j = 0;j < ranks.size();j ++){
+        for(std::size_t j = 0;j < ranks.size();j ++){
             this->ui_p2_range[i][j] = vector<pair<int,int>>();
         }
     }
@@ -247,15 +247,15 @@ void TableStrategyModel::updateStrategyData(){
                     vector<vector<vector<float>>> current_strategy = this->qSolverJob->get_solver()->get_solver()->get_strategy(iterActionNode,deal_cards);
 
                     int child_chosen = -1;
-                    for(int i = 0;i < iterActionNode->getChildrens().size();i ++){
+                    for(std::size_t i = 0;i < iterActionNode->getChildrens().size();i ++){
                         if(iterActionNode->getChildrens()[i] == last_node){
                             child_chosen = i;
                             break;
                         }
                     }
                     if(child_chosen == -1)throw runtime_error("no child chosen");
-                    for(int i = 0;i < 52;i ++){
-                        for(int j = 0;j < 52;j ++){
+                    for(std::size_t i = 0;i < 52;i ++){
+                        for(std::size_t j = 0;j < 52;j ++){
                             if(current_strategy[i][j].size() == 0)continue;
                             if(iterActionNode->getPlayer() == 0){ // p1, IP
                                 this->p1_range[i][j] *= current_strategy[i][j][child_chosen];
@@ -293,8 +293,8 @@ const vector<pair<GameActions,pair<float,float>>> TableStrategyModel::get_total_
         vector<float> avg_strategy(gameActions.size(),0.0);
         float sum_strategy = 0;
 
-        for(int index1 = 0;index1 < this->current_strategy.size() ;index1 ++){
-            for(int index2 = 0;index2 < this->current_strategy.size() ;index2 ++){
+        for(std::size_t index1 = 0;index1 < this->current_strategy.size() ;index1 ++){
+            for(std::size_t index2 = 0;index2 < this->current_strategy.size() ;index2 ++){
                 const vector<float>& one_strategy = this->current_strategy[index1][index2];
                 if(one_strategy.empty())continue;
 
@@ -302,7 +302,7 @@ const vector<pair<GameActions,pair<float,float>>> TableStrategyModel::get_total_
                 if(range.size() <= index1 || range[index1].size() < index2) throw runtime_error(" index error when get range in tablestrategymodel");
                 const float one_range = range[index1][index2];
 
-                for(int i = 0;i < one_strategy.size(); i ++ ){
+                for(std::size_t i = 0;i < one_strategy.size(); i ++ ){
                     float one_prob = one_strategy[i];
                     combos[i] += one_prob * one_range;
                     avg_strategy[i] += one_prob * one_range;
@@ -317,7 +317,7 @@ const vector<pair<GameActions,pair<float,float>>> TableStrategyModel::get_total_
             }
         }
 
-        for(int i = 0;i < gameActions.size(); i ++ ){
+        for(std::size_t i = 0;i < gameActions.size(); i ++ ){
             avg_strategy[i] = avg_strategy[i] / sum_strategy;
             pair<float,float> statics = pair<float,float>(combos[i],avg_strategy[i]);
             pair<GameActions,pair<float,float>> one_ret = pair<GameActions,pair<float,float>>(gameActions[i],statics);
@@ -358,7 +358,7 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
 
         float range_number = 0;
         if(!card_cords.empty()){
-            for(int indi = 0;indi < card_cords.size();indi ++){
+            for(std::size_t indi = 0;indi < card_cords.size();indi ++){
                     range_number += (*current_range)[card_cords[indi].first][card_cords[indi].second];
             }
             range_number = range_number / card_cords.size();
@@ -385,12 +385,12 @@ const vector<pair<GameActions,float>> TableStrategyModel::get_strategy(int i,int
             }
 
             if ( range_number > 0)
-                for(int indi = 0;indi < one_strategy.size();indi ++){
+                for(std::size_t indi = 0;indi < one_strategy.size();indi ++){
                     strategies[indi] += (one_strategy[indi] * (*current_range)[index1][index2] / range_number / strategy_number);
                 }
         }
 
-        for(int indi = 0;indi < strategies.size();indi ++){
+        for(std::size_t indi = 0;indi < strategies.size();indi ++){
             ret_strategy.push_back(std::pair<GameActions,float>(actionNode->getActions()[indi],
                                                                 strategies[indi]));
         }
@@ -435,7 +435,7 @@ const vector<float> TableStrategyModel::get_ev_grid(int i,int j)const{
                 throw runtime_error("size not match between gameAction and stragegy");
             }
             float one_ev_float = 0;
-            for(int indi = 0;indi < one_strategy.size();indi ++){
+            for(std::size_t indi = 0;indi < one_strategy.size();indi ++){
                 one_ev_float += one_strategy[indi] * one_ev[indi];
             }
             ret_evs.push_back(one_ev_float);
@@ -485,13 +485,13 @@ const vector<float> TableStrategyModel::get_strategies_evs(int i,int j)const{
                      << one_ev.size() << " " << gameActions.size() << " " << one_strategy.size() << endl;
                 throw runtime_error("size not match between one_ev, gameAction and one_stragegy");
             }
-            for(int indi = 0;indi < ret_evs.size();indi ++){
+            for(std::size_t indi = 0;indi < ret_evs.size();indi ++){
                 ret_evs[indi] += one_strategy[indi] * one_ev[indi] * one_range;
                 strategy_p[indi] += one_strategy[indi] * one_range;
             }
             range += one_range;
         }
-        for(int indi = 0;indi < ret_evs.size();indi ++){
+        for(std::size_t indi = 0;indi < ret_evs.size();indi ++){
             if (strategy_p[indi] > 0. && range > 0.) {
                 ret_evs[indi] = ret_evs[indi] / strategy_p[indi];
             }

--- a/src/ui/treeitem.cpp
+++ b/src/ui/treeitem.cpp
@@ -61,7 +61,7 @@ QVariant TreeItem::data() const
         shared_ptr<ActionNode> parentActionNode = dynamic_pointer_cast<ActionNode>(parentNode);
         vector<GameActions>& actions = parentActionNode->getActions();
         vector<shared_ptr<GameTreeNode>>& childrens = parentActionNode->getChildrens();
-        for(int i = 0;i < childrens.size();i ++){
+        for(std::size_t i = 0;i < childrens.size();i ++){
             if(childrens[i] == currentNode){
                 float amount = childrens[i]->getPot() - parentNode->getPot();
                 return (parentActionNode->getPlayer() == 0 ? QObject::tr("IP "):QObject::tr("OOP ")) + \


### PR DESCRIPTION
This PR fixes #185 by updating `for` loops to replace `int` with `std::size_t` to represent `std::vector` indices.