### PR TITLE
Replaces std::size_t with int in for loops to prevent errors 

### DIFF
--- a/src/solver/BestResponse.cpp
+++ b/src/solver/BestResponse.cpp
@@ -415,7 +415,7 @@ BestResponse::showdownBestResponse(shared_ptr<ShowdownNode> node, int player,con
     vector<float> card_winsum(52);
     for(std::size_t i = 0;i < card_winsum.size();i ++) card_winsum[i] = 0;
 
-    std::size_t j = 0;
+    int j = 0;
     //if(player_combs.length != oppo_combs.length) throw new RuntimeException("");
 
     for(std::size_t i = 0;i < player_combs.size();i ++){

--- a/src/solver/PCfrSolver.cpp
+++ b/src/solver/PCfrSolver.cpp
@@ -607,7 +607,7 @@ PCfrSolver::showdownUtility(int player, shared_ptr<ShowdownNode> node, const vec
     vector<float> card_winsum = vector<float> (52);//node->card_sum;
     fill(card_winsum.begin(),card_winsum.end(),0);
 
-    std::size_t j = 0;
+    int j = 0;
     for(std::size_t i = 0;i < player_combs.size();i ++){
         const RiverCombs& one_player_comb = player_combs[i];
         while (j < oppo_combs.size() && one_player_comb.rank < oppo_combs[j].rank){


### PR DESCRIPTION
This PR reverts two places changed in #186, where the unsigned size_t causes problems when the loop index is decremented beyond zero.